### PR TITLE
Add Quest 3S to QA Section to avoid confusion

### DIFF
--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -98,7 +98,7 @@
       },
       "question-10": {
         "question": "Which Headsets Are Compatible With SlimeVR?",
-        "answer": "SlimeVR Trackers work with any modern VR or XR headset that can work with SteamVR, as well as many standalone headsets, including but not limited to Valve Index, Meta Quest 1, 2, 3 or Pro, HTC Vive, Vive Pro, Varjo, Bigscreen Beyond, Pico 3, Pico 4, and many-many others!"
+        "answer": "SlimeVR Trackers work with any modern VR or XR headset that can work with SteamVR, as well as many standalone headsets, including but not limited to Valve Index, Meta Quest 1, 2, 3, 3S, or Pro, HTC Vive, Vive Pro, Varjo, Bigscreen Beyond, Pico 3, Pico 4, and many-many others!"
       },
       "question-11": {
         "question": "Which vTubing Software Is SlimeVR Compatible With?",


### PR DESCRIPTION
One of my friends was looking into trackers for VRChat, but they didn't see the 3S listed in the compatibility QA so it threw them off and they thought it wasn't compatible.