### PR TITLE
refactor: extract theme tokens into dedicated theme.css, add M3 tokens

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1,129 +1,11 @@
 @import "tailwindcss";
+@import "./theme.css";
 @plugin "@tailwindcss/typography";
 
 :root {
   --font-size-standard: var(--font-size);
-  /* 30% bigger */
   --font-size-section-title: calc(var(--font-size) * 1.3);
-  /* 100.08% bigger */
   --font-size-title: calc(var(--font-size) * 2.2);
-}
-
-@theme {
-  --default-font-family: "Poppins";
-
-  --color-background-10: rgb(255, 255, 255);
-  --color-background-20: rgb(120, 164, 198);
-  --color-background-30: rgb(96, 138, 171);
-  --color-background-40: rgb(61, 99, 129);
-  --color-background-50: rgb(26, 61, 89);
-  --color-background-60: rgb(17, 45, 67);
-  --color-background-70: rgb(8, 30, 48);
-  --color-background-80: rgb(0, 16, 28);
-  --color-background-90: rgb(0, 5, 9);
-
-  --color-accent-background-10: rgb(187, 138, 229);
-  --color-accent-background-20: rgb(157, 92, 212);
-  --color-accent-background-30: rgb(101, 69, 154);
-  --color-accent-background-40: rgb(98, 59, 131);
-  --color-accent-background-50: rgb(46, 33, 69);
-  --color-accent-background-60: rgb(30, 35, 60);
-  --color-accent-background-25: rgb(234, 0, 255, 0.4);
-
-  --color-status-success: rgb(80, 232, 151);
-  --color-status-warning: rgb(216, 205, 55);
-  --color-status-critical: rgb(223, 109, 140);
-  --color-status-special: rgb(164, 79, 237);
-
-  --color-window-icon-stroke: rgb(192, 161, 216);
-
-  --breakpoint-sm: 640px;
-  --breakpoint-md: 932px;
-  --breakpoint-lg: 1024px;
-  --breakpoint-mid: 1180px;
-  --breakpoint-2xl: 1836px;
-
-  --animate-explode: explode 6s ease-out;
-  @keyframes explode {
-    0% {
-      transform-origin: -100% 50%;
-      transform: scale(0);
-      rotate: 0deg;
-      opacity: 1;
-    }
-    70% {
-      transform: scale(100%);
-    }
-    100% {
-      transform: scale(100%);
-      rotate: 360deg;
-      opacity: 0;
-    }
-  }
-
-  --animate-floating: floating 12s cubic-bezier(0.64, 0.57, 0.67, 1.53) infinite;
-  @keyframes floating {
-    0% {
-      transform: translateY(0%);
-    }
-    50% {
-      transform: translateY(3%);
-    }
-    100% {
-      transform: translateY(0%);
-    }
-  }
-
-  --animate-rotated: rotated 6s ease-in-out infinite;
-  @keyframes rotated {
-    0% {
-      rotate: 0deg;
-    }
-    50% {
-      rotate: 3deg;
-    }
-    100% {
-      rotate: 0deg;
-    }
-  }
-
-  --animate-nighty: nighty 12s cubic-bezier(0.64, 0.57, 0.67, 1.53) infinite;
-  @keyframes nighty {
-    0% {
-      rotate: 1.5deg;
-      transform: translateY(0%);
-    }
-    50% {
-      rotate: 0deg;
-      transform: translateY(3%);
-    }
-    100% {
-      rotate: 1.5deg;
-      transform: translateY(0%);
-    }
-  }
-
-  --animate-stars: stars 2s ease-in-out infinite;
-  @keyframes stars {
-    0%,
-    100% {
-      opacity: 1;
-    }
-    50% {
-      opacity: 0.5;
-    }
-  }
-
-  --animate-stars2: stars2 2s ease-in-out infinite;
-  @keyframes stars2 {
-    0%,
-    100% {
-      opacity: 0.5;
-    }
-    50% {
-      opacity: 1;
-    }
-  }
 }
 
 @utility text-main-title {
@@ -181,15 +63,15 @@ a.link {
 }
 
 .linear-gradient {
-  background: #5f9d34;
+  background: var(--color-status-success);
   background: radial-gradient(
     at center,
-    #5f9d34,
-    #5595bc,
-    #ddda1d,
-    #630fc4,
-    #0f6dc4,
-    #0fc42d
+    var(--color-status-success),
+    var(--color-secondary),
+    var(--color-status-warning),
+    var(--color-primary-container),
+    var(--color-secondary-container),
+    var(--color-status-success)
   );
 }
 
@@ -215,9 +97,9 @@ a.link {
 
 /* OverlayScrollbars styling */
 .os-scrollbar-handle {
-  background: rgba(255, 255, 255, 0.6) !important;
+  background: color-mix(in srgb, var(--color-on-surface) 60%, transparent) !important;
 }
 
 .os-scrollbar-handle:hover {
-  background: rgba(255, 255, 255, 0.8) !important;
+  background: color-mix(in srgb, var(--color-on-surface) 80%, transparent) !important;
 }

--- a/src/theme.css
+++ b/src/theme.css
@@ -1,0 +1,152 @@
+@theme {
+  --default-font-family: "Poppins";
+
+  --color-background-10: rgb(255, 255, 255);
+  --color-background-20: rgb(120, 164, 198);
+  --color-background-30: rgb(96, 138, 171);
+  --color-background-40: rgb(61, 99, 129);
+  --color-background-50: rgb(26, 61, 89);
+  --color-background-60: rgb(17, 45, 67);
+  --color-background-70: rgb(8, 30, 48);
+  --color-background-80: rgb(0, 16, 28);
+  --color-background-90: rgb(0, 5, 9);
+
+  --color-accent-background-10: rgb(187, 138, 229);
+  --color-accent-background-20: rgb(157, 92, 212);
+  --color-accent-background-30: rgb(101, 69, 154);
+  --color-accent-background-40: rgb(98, 59, 131);
+  --color-accent-background-50: rgb(46, 33, 69);
+  --color-accent-background-60: rgb(30, 35, 60);
+  --color-accent-background-25: rgb(234, 0, 255, 0.4);
+
+  --color-status-success: rgb(80, 232, 151);
+  --color-status-warning: rgb(216, 205, 55);
+  --color-status-critical: rgb(223, 109, 140);
+  --color-status-special: rgb(164, 79, 237);
+
+  --color-window-icon-stroke: rgb(192, 161, 216);
+
+  /* Material 3 — Primary (Purple) */
+  --color-primary: #9D5CD4;
+  --color-on-primary: #FFFFFF;
+  --color-primary-container: #65459A;
+  --color-on-primary-container: #EAD9FF;
+
+  /* Material 3 — Secondary (Blue-grey) */
+  --color-secondary: #78A4C6;
+  --color-on-secondary: #FFFFFF;
+  --color-secondary-container: #3D6381;
+  --color-on-secondary-container: #D3E6F7;
+
+  /* Material 3 — Tertiary (Green) */
+  --color-tertiary: #50E897;
+  --color-on-tertiary: #003920;
+  --color-tertiary-container: #1B7A48;
+  --color-on-tertiary-container: #A4F7C5;
+
+  /* Material 3 — Error (Pink-red) */
+  --color-error: #DF6D8C;
+  --color-on-error: #FFFFFF;
+  --color-error-container: #A63D5C;
+  --color-on-error-container: #FFD9E2;
+
+  /* Material 3 — Neutral */
+  --color-surface: #112D43;
+  --color-on-surface: #FFFFFF;
+  --color-surface-variant: #1A3D59;
+  --color-on-surface-variant: #B8CDE0;
+  --color-background: #081E30;
+  --color-on-background: #E1EFF9;
+
+  /* Material 3 — Outline */
+  --color-outline: #4A6E88;
+  --color-outline-variant: #38536A;
+
+  --breakpoint-sm: 640px;
+  --breakpoint-md: 932px;
+  --breakpoint-lg: 1024px;
+  --breakpoint-mid: 1180px;
+  --breakpoint-2xl: 1836px;
+
+  --animate-explode: explode 6s ease-out;
+  @keyframes explode {
+    0% {
+      transform-origin: -100% 50%;
+      transform: scale(0);
+      rotate: 0deg;
+      opacity: 1;
+    }
+    70% {
+      transform: scale(100%);
+    }
+    100% {
+      transform: scale(100%);
+      rotate: 360deg;
+      opacity: 0;
+    }
+  }
+
+  --animate-floating: floating 12s cubic-bezier(0.64, 0.57, 0.67, 1.53) infinite;
+  @keyframes floating {
+    0% {
+      transform: translateY(0%);
+    }
+    50% {
+      transform: translateY(3%);
+    }
+    100% {
+      transform: translateY(0%);
+    }
+  }
+
+  --animate-rotated: rotated 6s ease-in-out infinite;
+  @keyframes rotated {
+    0% {
+      rotate: 0deg;
+    }
+    50% {
+      rotate: 3deg;
+    }
+    100% {
+      rotate: 0deg;
+    }
+  }
+
+  --animate-nighty: nighty 12s cubic-bezier(0.64, 0.57, 0.67, 1.53) infinite;
+  @keyframes nighty {
+    0% {
+      rotate: 1.5deg;
+      transform: translateY(0%);
+    }
+    50% {
+      rotate: 0deg;
+      transform: translateY(3%);
+    }
+    100% {
+      rotate: 1.5deg;
+      transform: translateY(0%);
+    }
+  }
+
+  --animate-stars: stars 2s ease-in-out infinite;
+  @keyframes stars {
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.5;
+    }
+  }
+
+  --animate-stars2: stars2 2s ease-in-out infinite;
+  @keyframes stars2 {
+    0%,
+    100% {
+      opacity: 0.5;
+    }
+    50% {
+      opacity: 1;
+    }
+  }
+}


### PR DESCRIPTION
- Move @theme block from app.css to theme.css
- Add Material 3 design token aliases (primary, secondary, tertiary, error, surface, etc.)
- Replace hardcoded colors in .linear-gradient and .os-scrollbar-handle with theme vars
- Import theme.css from app.css