### PR TITLE
Implemented the news/blog section on top of the existing route scaffolding

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1,6 +1,50 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 
+/* Prose visual overrides for markdown content rendered via NewsPostContent.
+   Text colors are set via prose-* Tailwind variant classes on the component. */
+.prose-slime {
+  :where(code) {
+    background-color: var(--color-background-80);
+    padding: 0.125rem 0.375rem;
+    border-radius: 0.25rem;
+  }
+
+  :where(code)::before,
+  :where(code)::after {
+    content: none;
+  }
+
+  :where(pre) {
+    border: 1px solid var(--color-background-40);
+    border-radius: 0.75rem;
+  }
+
+  :where(blockquote) {
+    background-color: var(--color-background-80);
+    padding: 0.75rem 1.25rem;
+    border-radius: 0 0.75rem 0.75rem 0;
+    font-weight: 400;
+    font-style: normal;
+  }
+
+  :where(th),
+  :where(td) {
+    border: 1px solid var(--color-background-40);
+    padding: 0.5rem 0.75rem;
+  }
+
+  :where(tbody tr:nth-child(even)) {
+    background-color: color-mix(in srgb, var(--color-background-80) 50%, transparent);
+  }
+
+  :where(img) {
+    border-radius: 0.75rem;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
 :root {
   --font-size-standard: var(--font-size);
   /* 30% bigger */
@@ -42,6 +86,7 @@
   --breakpoint-lg: 1024px;
   --breakpoint-mid: 1180px;
   --breakpoint-2xl: 1836px;
+  --breakpoint-ultrawide: 2560px;
 
   --animate-explode: explode 6s ease-out;
   @keyframes explode {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -209,7 +209,7 @@
     "title": "SlimeVR Trademark Guidelines"
   },
   "news": {
-    "title": "Latest news",
+    "title": "Latest News",
     "none": "No news posts yet.",
     "later": "Check back later!"
   },

--- a/src/components/news/NewsCard.tsx
+++ b/src/components/news/NewsCard.tsx
@@ -1,0 +1,54 @@
+import { A } from "@solidjs/router";
+import clsx from "clsx";
+import { Component, createMemo } from "solid-js";
+import { Typography } from "~/components/commons/Typography";
+
+interface NewsCardProps {
+  slug: string;
+  title: string;
+  date: string;
+  description: string;
+  imageUrl?: string;
+}
+
+export const NewsCard: Component<NewsCardProps> = (props) => {
+  const classes = createMemo(() =>
+    clsx(
+      "group relative flex flex-col rounded-2xl overflow-hidden",
+      "bg-background-70 border border-background-40",
+      "hover:bg-background-60",
+      "transition-all duration-200 ease-standard",
+      "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-background-20"
+    )
+  );
+
+  return (
+    <A href={`/news/${props.slug}`} class={classes()}>
+      <img
+        src={props.imageUrl || "/images/nighty_floating.webp"}
+        alt=""
+        loading="lazy"
+        class="w-full h-48 object-cover no-interact"
+      />
+      <div class="flex flex-col gap-1 p-4">
+        <span class="text-xs font-medium text-background-30 uppercase tracking-widest">
+          {props.date}
+        </span>
+        <Typography
+          tag="h3"
+          variant="section-title"
+          class="text-background-10 group-hover:text-white transition-colors duration-200"
+        >
+          {props.title}
+        </Typography>
+        <Typography tag="p" class="text-sm leading-relaxed mt-1 text-background-20 line-clamp-3">
+          {props.description}
+        </Typography>
+      </div>
+      <div
+        aria-hidden="true"
+        class="absolute inset-0 bg-background-10 opacity-0 transition-opacity duration-200 group-hover:opacity-[0.05] group-active:opacity-[0.08] group-focus-visible:opacity-[0.08]"
+      />
+    </A>
+  );
+};

--- a/src/components/news/NewsList.tsx
+++ b/src/components/news/NewsList.tsx
@@ -1,0 +1,45 @@
+import { Component, For, Show } from "solid-js";
+import { Typography } from "~/components/commons/Typography";
+import { NewsCard } from "~/components/news";
+import type { Post } from "~/types/posts";
+
+interface NewsListProps {
+  posts: Post[] | undefined;
+}
+
+export const NewsList: Component<NewsListProps> = (props) => {
+  return (
+    <Show
+      when={(props.posts?.length ?? 0) > 0}
+      fallback={
+        <div class="rounded-2xl bg-background-70 border border-background-40 px-5 text-center py-10">
+          <Typography
+            tag="p"
+            variant="section-title"
+            key="news.none"
+          ></Typography>
+          <Typography
+            tag="p"
+            color="secondary"
+            class="mt-2"
+            key="news.later"
+          ></Typography>
+        </div>
+      }
+    >
+      <div class="grid gap-4 grid-cols-1 md:grid-cols-2">
+        <For each={props.posts}>
+          {(post) => (
+            <NewsCard
+              slug={post.slug}
+              title={post.metadata.title}
+              date={post.metadata.date}
+              description={post.metadata.description}
+              imageUrl={post.metadata.imageUrl}
+            />
+          )}
+        </For>
+      </div>
+    </Show>
+  );
+};

--- a/src/components/news/NewsPageHeader.tsx
+++ b/src/components/news/NewsPageHeader.tsx
@@ -1,0 +1,14 @@
+import { Component } from "solid-js";
+import { Typography } from "~/components/commons/Typography";
+
+export const NewsPageHeader: Component = () => {
+  return (
+    <div class="mb-6 2xl:text-center">
+      <Typography
+        tag="h1"
+        variant="main-title"
+        key="news.title"
+      ></Typography>
+    </div>
+  );
+};

--- a/src/components/news/NewsPostContent.tsx
+++ b/src/components/news/NewsPostContent.tsx
@@ -1,0 +1,10 @@
+import { Component } from "solid-js";
+
+interface NewsPostContentProps {
+  html: string;
+}
+
+/** Renders pre-compiled `.md` HTML. Text colors via prose-* Tailwind variant classes. */
+export const NewsPostContent: Component<NewsPostContentProps> = (props) => {
+  return <div innerHTML={props.html} class="prose prose-base lg:prose-xl max-w-none prose-p:text-background-10 prose-headings:text-background-10 prose-a:text-background-20 prose-strong:text-background-10 prose-code:text-accent-background-10 prose-pre:text-background-10 prose-li:text-background-10 prose-th:text-background-10 prose-td:text-background-10 prose-blockquote:text-background-10 prose-slime" />;
+};

--- a/src/components/news/NewsPostHeader.tsx
+++ b/src/components/news/NewsPostHeader.tsx
@@ -1,0 +1,27 @@
+import { Component } from "solid-js";
+import { Typography } from "~/components/commons/Typography";
+
+interface NewsPostHeaderProps {
+  title: string;
+  date: string;
+  description: string;
+}
+
+export const NewsPostHeader: Component<NewsPostHeaderProps> = (props) => {
+  return (
+    <div class="relative overflow-clip rounded-xl">
+      <div class="absolute inset-0 opacity-25 pattern" />
+      <div class="relative flex flex-col gap-3">
+        <Typography tag="p" class="text-xs tracking-widest uppercase text-background-30 font-medium">
+          {props.date}
+        </Typography>
+        <Typography tag="h1" class="text-3xl sm:text-4xl font-bold leading-tight text-background-10">
+          {props.title}
+        </Typography>
+        <Typography tag="p" class="text-base leading-relaxed text-background-30 max-w-3xl">
+          {props.description}
+        </Typography>
+      </div>
+    </div>
+  );
+};

--- a/src/components/news/index.ts
+++ b/src/components/news/index.ts
@@ -1,0 +1,5 @@
+export * from "./NewsCard";
+export * from "./NewsList";
+export * from "./NewsPageHeader";
+export * from "./NewsPostContent";
+export * from "./NewsPostHeader";

--- a/src/routes/news/[slug].tsx
+++ b/src/routes/news/[slug].tsx
@@ -1,20 +1,16 @@
+import { A, useParams } from "@solidjs/router";
 import { Link, Meta, Title } from "@solidjs/meta";
-import { useLocation } from "@solidjs/router";
 import { createMemo, createResource, Show } from "solid-js";
-import { Container } from "~/components/commons/Container";
+import { NewsPostContent } from "~/components/news";
 import { Typography } from "~/components/commons/Typography";
 import { Section } from "~/components/Section";
 import { MainLayout } from "~/layouts/MainLayout";
-import type { Post } from "~/utils/posts";
+import type { Post } from "~/types/posts";
 
 export default function PostPage() {
-  const location = useLocation();
-  const slug = createMemo(() => {
-    const parts = location.pathname.split("/");
-    return parts[parts.length - 1];
-  });
+  const params = useParams<{ slug: string }>();
   const [post] = createResource<Post | null, string>(
-    () => slug(),
+    () => params.slug,
     async (slug) => {
       const { getPost } = await import("~/utils/posts");
       return getPost(slug);
@@ -30,37 +26,46 @@ export default function PostPage() {
         <Title>{`${metadata()?.title} - SlimeVR Official`}</Title>
       </Show>
       <Meta name="robots" content="index, follow" />
-      <Link rel="canonical" href={`https://slimevr.dev/news/${slug()}`} />
+      <Link rel="canonical" href={`https://slimevr.dev/news/${params.slug}`} />
 
       <Section>
-        <div class="flex flex-col gap-6 py-6 sm:py-10">
-          <Container class="relative overflow-clip">
-            <div class="absolute inset-0 opacity-35 pattern"></div>
-            <div class="relative flex flex-col gap-3">
-              <Show
-                when={post()}
-                fallback={
-                  <Typography tag="h1" variant="section-title">
-                    Loading post...
-                  </Typography>
-                }
+        <Show
+          when={post()}
+          fallback={
+            <Typography tag="h1" variant="section-title">
+              Loading post...
+            </Typography>
+          }
+        >
+          <div class="rounded-2xl bg-background-70 border border-background-40 p-6 md:p-8 my-10">
+            <A
+              href="/news"
+              class="inline-flex items-center gap-1 text-sm text-background-30 hover:text-background-10 transition-colors mb-6"
+            >
+              <svg
+                class="w-4 h-4"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
               >
-                <>
-                  <Typography tag="h1" variant="section-title">
-                    {metadata()?.title}
-                  </Typography>
-                  <Typography tag="p" color="secondary">
-                    {metadata()?.date}
-                  </Typography>
-                  <Typography tag="p" class="max-w-3xl" color="secondary">
-                    {metadata()?.description}
-                  </Typography>
-                </>
-              </Show>
-            </div>
-          </Container>
+                <path d="M19 12H5m7-7-7 7 7 7" />
+              </svg>
+              Back to news
+            </A>
 
-          <Container class="flex flex-col gap-4">
+            <div class="relative overflow-clip rounded-xl">
+              <div class="absolute inset-0 opacity-25 pattern" />
+              <div class="relative flex flex-col">
+                <Typography tag="p" class="text-xs font-medium tracking-widest text-background-30">
+                  {metadata()!.date}
+                </Typography>
+                <Typography tag="h1" class="text-3xl sm:text-4xl font-bold leading-tight text-background-10 pb-10">
+                  {metadata()!.title}
+                </Typography>
+              </div>
+            </div>
+
             <Show
               when={html()}
               fallback={
@@ -69,13 +74,10 @@ export default function PostPage() {
                 </Typography>
               }
             >
-              <div
-                innerHTML={html()}
-                class="text-sm w-full min-w-full prose-xl prose text-background-10 prose-h1:text-background-10 prose-h2:text-background-10 prose-h3:text-background-10 prose-h3:text-2xl prose-h4:text-background-10 prose-h4:text-xl prose-a:text-background-20 prose-strong:text-background-10 prose-code:text-background-20 prose-blockquote:text-background-10 prose-blockquote:border-background-30 prose-thead:text-background-10 prose-th:text-background-10 prose-td:text-background-10 prose-ul:list-disc prose-li:marker:text-background-10"
-              />
+              <NewsPostContent html={html()!} />
             </Show>
-          </Container>
-        </div>
+          </div>
+        </Show>
       </Section>
     </MainLayout>
   );

--- a/src/routes/news/index.tsx
+++ b/src/routes/news/index.tsx
@@ -1,12 +1,10 @@
 import { Link, Meta } from "@solidjs/meta";
-import { A } from "@solidjs/router";
-import { createResource, For } from "solid-js";
+import { createResource } from "solid-js";
 import { AppTitle } from "~/components/AppTitle";
-import { Container } from "~/components/commons/Container";
-import { Typography } from "~/components/commons/Typography";
+import { NewsList, NewsPageHeader } from "~/components/news";
 import { Section } from "~/components/Section";
 import { MainLayout } from "~/layouts/MainLayout";
-import type { Post } from "~/utils/posts";
+import type { Post } from "~/types/posts";
 
 export default function NewsPage() {
   const [posts] = createResource<Post[]>(async () => {
@@ -19,70 +17,11 @@ export default function NewsPage() {
       <AppTitle key="news.title"></AppTitle>
       <Meta name="robots" content="index, follow" />
       <Link rel="canonical" href="https://slimevr.dev/news" />
-
       <Section>
-        <Container class="mt-4">
-          <div class="mb-8">
-            <Typography
-              tag="h1"
-              variant="main-title"
-              key="news.title"
-            ></Typography>
-          </div>
-
-          <Typography tag="p">
-            Lorem ipsum dolor sit amet consectetur adipiscing elit. Sed euismod,
-            nisl nec tincidunt lacinia, nunc est aliquam nunc, eget aliquam nisl
-            nunc eget nunc.
-          </Typography>
-
-          {/* news posts */}
-          <div class="mt-8">
-            {(posts()?.length ?? 0) > 0 ? (
-              <div class="grid gap-3 grid-cols-1 md:grid-cols-2">
-                <For each={posts()}>
-                  {(post) => (
-                    <A
-                      href={`/news/${post.slug}`}
-                      class="group flex flex-col gap-2 rounded-2xl border border-background-40 bg-background-60 px-5 py-4 transition-colors hover:bg-background-50"
-                    >
-                      <div class="flex items-start justify-between gap-4">
-                        <div class="flex flex-col gap-1">
-                          <Typography
-                            tag="h3"
-                            variant="section-title"
-                            class="group-hover:text-background-20 transition-colors"
-                          >
-                            {post.metadata.title}
-                          </Typography>
-                          <Typography tag="p" color="secondary" class="text-sm">
-                            {post.metadata.date}
-                          </Typography>
-                        </div>
-                      </div>
-                      <Typography tag="p" color="secondary">
-                        {post.metadata.description}
-                      </Typography>
-                    </A>
-                  )}
-                </For>
-              </div>
-            ) : (
-              <div class="rounded-2xl border border-dashed border-background-40 bg-background-70 px-5 py-8 text-center">
-                <Typography
-                  tag="p"
-                  variant="section-title"
-                  key="news.none"
-                ></Typography>
-                <Typography
-                  tag="p"
-                  color="secondary"
-                  key="news.later"
-                ></Typography>
-              </div>
-            )}
-          </div>
-        </Container>
+        <div class="flex flex-col relative p-5 my-5 min-[1440px]:my-10">
+          <NewsPageHeader />
+          <NewsList posts={posts()} />
+        </div>
       </Section>
     </MainLayout>
   );

--- a/src/routes/news/posts/index.json
+++ b/src/routes/news/posts/index.json
@@ -1,0 +1,16 @@
+[
+  {
+    "slug": "test-2",
+    "title": "Weekly Dev Update #239",
+    "date": "2026-07-11",
+    "description": "A week ago we ran a poll and asked for feedback on the most common issues you experience when using SlimeVR, and the response was immense. First up, thank you everyone who responded. Your feedback helps us direct our efforts effectively, and we want to use today's update to go over the most common issues that came up, and our plans to address them.",
+    "imageUrl": null
+  },
+  {
+    "slug": "test",
+    "title": "Weekly Dev Update #238",
+    "date": "2026-07-02",
+    "description": "Hiyo Slimes, Spazzwan:SKC_SpazzwanLogo:here, hoping those of you in the upper half of the world are surviving this very normal summer. Do not become cooked, please stay cool and hydrate!",
+    "imageUrl": null
+  }
+]

--- a/src/routes/news/posts/test-2.md
+++ b/src/routes/news/posts/test-2.md
@@ -1,0 +1,58 @@
+---
+title: "Weekly Dev Update #238"
+date: "2026-07-02"
+description: "Hiyo Slimes, Spazzwan:SKC_SpazzwanLogo:here, hoping those of you in the upper half of the world are surviving this very normal summer. Do not become cooked, please stay cool and hydrate!"
+---
+
+something something hi this is a blog example to show off the formatting
+
+you can do stuff idk, make things **bold**, _italic_, ~~struck through~~, or link [somewhere](/news) ok
+
+# example
+
+## example 2
+
+### example 3
+
+#### example 4
+
+- hello
+- world
+- yes
+
+1. never gonna
+2. give you
+3. up
+
+reference images like this `![example](/images/news/[slug]/[image])`: ![example](/images/nighty_floating.webp)
+
+inline code `bun run dev` then some code blocks:
+
+```typescript
+// typescript
+function hello(name: String) {
+    console.log(`Hello ${name}`);
+}
+
+hello("World");
+```
+
+```python
+# python
+def hello(name):
+  print(f'Hello {name}')
+
+hello('World')
+```
+
+> "meow"
+> — maya
+
+and make tables or something:
+
+| statement    | never gonna |
+| ------------ | ----------- |
+| give you up  | ✅          |
+| let you down | ✅          |
+| run around   | ✅          |
+| desert you   | ✅          |

--- a/src/routes/news/posts/test.md
+++ b/src/routes/news/posts/test.md
@@ -1,0 +1,58 @@
+---
+title: "Weekly Dev Update #239"
+date: "2026-07-11"
+description: "A week ago we ran a poll and asked for feedback on the most common issues you experience when using SlimeVR, and the response was immense. First up, thank you everyone who responded. Your feedback helps us direct our efforts effectively, and we want to use today's update to go over the most common issues that came up, and our plans to address them."
+---
+
+something something hi this is a blog example to show off the formatting
+
+you can do stuff idk, make things **bold**, _italic_, ~~struck through~~, or link [somewhere](/news) ok
+
+# example
+
+## example 2
+
+### example 3
+
+#### example 4
+
+- hello
+- world
+- yes
+
+1. never gonna
+2. give you
+3. up
+
+reference images like this `![example](/images/news/[slug]/[image])`: ![example](/images/nighty_floating.webp)
+
+inline code `bun run dev` then some code blocks:
+
+```typescript
+// typescript
+function hello(name: String) {
+    console.log(`Hello ${name}`);
+}
+
+hello("World");
+```
+
+```python
+# python
+def hello(name):
+  print(f'Hello {name}')
+
+hello('World')
+```
+
+> "meow"
+> — maya
+
+and make tables or something:
+
+| statement    | never gonna |
+| ------------ | ----------- |
+| give you up  | ✅          |
+| let you down | ✅          |
+| run around   | ✅          |
+| desert you   | ✅          |

--- a/src/types/posts.ts
+++ b/src/types/posts.ts
@@ -1,0 +1,13 @@
+export interface Post {
+  slug: string;
+  metadata: PostMetadata;
+  html?: string;
+  imageUrl?: string;
+}
+
+export interface PostMetadata {
+  title: string;
+  date: string;
+  description: string;
+  imageUrl?: string;
+}

--- a/src/utils/posts.ts
+++ b/src/utils/posts.ts
@@ -1,38 +1,24 @@
-// adapted from https://github.com/JovannMC/jovann.me/blob/main/src/lib/utils/posts.ts
-export interface Post {
-  slug: string;
-  metadata: PostMetadata;
-  html?: string;
-}
+import manifest from "~/routes/news/posts/index.json";
+import type { Post, PostMetadata } from "~/types/posts";
 
-export interface PostMetadata {
-  title: string;
-  date: string;
-  description: string;
-}
-
-export interface PostModule {
+interface PostModule {
   html: string;
   attributes: PostMetadata;
 }
 
-const postModules = import.meta.glob("/src/posts/*.md");
-const getSlug = (path: string) =>
-  path.split("/").pop()?.replace(".md", "") ?? "";
+const postModules = import.meta.glob("/src/routes/news/posts/*.md");
 
-export async function getPosts() {
-  const posts: Post[] = [];
+export async function getPosts(): Promise<Post[]> {
+  const posts: Post[] = manifest.map((entry) => ({
+    slug: entry.slug,
+    metadata: {
+      title: entry.title,
+      date: entry.date,
+      description: entry.description,
+      imageUrl: entry.imageUrl ?? undefined,
+    },
+  }));
 
-  for (const path in postModules) {
-    // direct imports of the files handled by vite-plugin-markdown
-    const mod = (await postModules[path]()) as PostModule;
-    const slug = getSlug(path);
-    const metadata = mod.attributes as PostMetadata;
-
-    posts.push({ slug, metadata });
-  }
-
-  // latest posts first
   return posts.sort((a, b) => {
     const dateA = new Date(a.metadata.date);
     const dateB = new Date(b.metadata.date);
@@ -41,7 +27,7 @@ export async function getPosts() {
 }
 
 export async function getPost(slug: string): Promise<Post | null> {
-  const importer = postModules[`/src/posts/${slug}.md`];
+  const importer = postModules[`/src/routes/news/posts/${slug}.md`];
   if (!importer) return null;
 
   const { attributes, html } = (await importer()) as PostModule;


### PR DESCRIPTION
- **Post page** (`/news/:slug`) - full markdown rendering with back-nav, header metadata
- **Components** — `NewsCard`, `NewsList`, `NewsPageHeader`, `NewsPostHeader`, `NewsPostContent`
- **2 draft posts** - test.md and test-2.md changed to represent more api
- **Ultrawide breakpoint** at 2560px

<img width="1823" height="1151" alt="{4F0F2F21-F25A-4290-B52A-EDAB8C6CE867}" src="https://github.com/user-attachments/assets/03b347f0-7321-428b-9f01-4f99dc9a370d" />
<img width="1887" height="1243" alt="{D54042BD-3939-4BBD-8AC0-1071689FB753}" src="https://github.com/user-attachments/assets/6c396703-af72-4536-b3b8-88d781b591c4" />

